### PR TITLE
test: fix path to test fixtures

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -11,13 +11,15 @@ const path = require('path');
 const fs = require('fs');
 
 // Ensure fixture dependencies are installed
-const fixtures = fs.readdirSync(`${__dirname}/fixtures`);
+const fixtureDir = path.join(__dirname, 'fixtures');
+const fixtures = fs.readdirSync(fixtureDir);
 fixtures.forEach(installDependenciesIfExist);
 
 function installDependenciesIfExist(functionPath) {
   if (path.extname(functionPath) !== '') {
     functionPath = path.dirname(functionPath);
   }
+  functionPath = path.join(fixtureDir, functionPath);
   if (existsSync(path.join(functionPath, 'package.json'))) {
     execSync('npm install --production', { cwd: functionPath });
   }


### PR DESCRIPTION
Currently, the test are failing with the following error:
```console
$ rm -rf test/fixtures/simple-http/node_modules/
$ npm t

> @redhat/faas-js-runtime@0.0.2 test /work/faas-js-runtime
> nyc tape test/*.js | tap-spec

  Loads a user function with dependencies

internal/modules/cjs/loader.js:626
    throw err;
    ^

Error: Cannot find module 'is-number'
Require stack:
/work/faas-js-runtime/test/fixtures/simple-http/index.js
/work/faas-js-runtime/test/test.js
```
This commit adds the fixture director so that the package.json files in
the fixtures are found.