### PR TITLE
src,doc: Add curl example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ module.exports = async function myFunction(context) {
   });
 };
 ```
+
+You can use `curl` to invoke the endpoint:
+```console
+$ curl -X POST -d 'hello=world' \
+  -H'Content-type: application/x-www-form-urlencoded' http://localhost:8080
+```
+
 ### Sample
 
 You can see this in action, executing the function at `test/fixtures/async`

--- a/index.js
+++ b/index.js
@@ -37,8 +37,6 @@ function start(func, port, cb) {
   // Incoming requests to the hosted function
   server.register(requestHandler, { func });
 
-  // eslint-disable-next-line max-len
-  // curl -X POST -d 'hello=world' -H'Content-type: application/x-www-form-urlencoded' http://localhost:8080/
   server.addContentTypeParser('application/x-www-form-urlencoded',
     function(req, done) {
       var body = '';


### PR DESCRIPTION
This command adds the curl example that is currently in index.js to the
readme.