### PR TITLE
src: don't initialize func

### DIFF
--- a/lib/request-handler.js
+++ b/lib/request-handler.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const eventHandler = require('./event-handler');
-let func = _ => { };
+let func;
 
 module.exports = function(fastify, opts, done) {
   func = opts.func;


### PR DESCRIPTION
Currently, the field func is initialized but it always gets overritten
as far as I can tell. This commit removes the initalization.