### PR TITLE
src: fix hack example

### DIFF
--- a/hack/run.js
+++ b/hack/run.js
@@ -1,3 +1,3 @@
 const path = require('path');
 
-require('..')(path.join(__dirname, '..', 'test', 'fixtures', 'async'));
+require('..')(require(path.join(__dirname, '..', 'test', 'fixtures', 'async')));


### PR DESCRIPTION
This commit adds a require function call for the example in the fixtures
directory. This require was previously done by the framework but that
was changed which broke this example.