### PR TITLE
src: remove unused 'context' property

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,6 @@ function start(func, port, cb, options) {
   const server = fastify({ logger: log });
 
   // All incoming requests get a Context object
-  server.decorateRequest('context');
   server.addHook('onRequest', (req, reply, done) => {
     req.context = new Context(req, reply);
     done();


### PR DESCRIPTION
Currently there is a property named 'context' added to the Fastify
instance but it is not given a value and I can't find any usage of it.

This commit removes this property.