### PR TITLE
src: add constants for cloudevent headers

### DIFF
--- a/lib/ce-constants.js
+++ b/lib/ce-constants.js
@@ -1,0 +1,10 @@
+const Spec = {
+  version: 'ce-specversion',
+  type: 'ce-type',
+  id: 'ce-id',
+  source: 'ce-source'
+};
+
+module.exports = {
+  Spec
+};

--- a/lib/event-handler.js
+++ b/lib/event-handler.js
@@ -3,6 +3,7 @@
 const v02 = require('cloudevents-sdk/v02');
 const v03 = require('cloudevents-sdk/v03');
 const v1 = require('cloudevents-sdk/v1');
+const Spec = require('./ce-constants.js').Spec;
 
 const v02Unmarshaller = new v02.HTTPUnmarshaller();
 const v03Unmarshaller = new v03.HTTPUnmarshaller();
@@ -18,7 +19,7 @@ function use(fastify, opts, done) {
     });
 
   fastify.decorateRequest('isCloudEvent', function() {
-    if ('ce-type' in this.req.headers) {
+    if (Spec.type in this.req.headers) {
       return true;
     } else {
       const contentType = this.req.headers['content-type'];
@@ -33,7 +34,7 @@ function use(fastify, opts, done) {
   // processed if it's a cloud event spec version we know about
   fastify.addHook('preHandler', async(request, reply) => {
     if (request.isCloudEvent()) {
-      const version = request.headers['ce-specversion'];
+      const version = request.headers[Spec.version];
       // if there is no version in the headers, it is a
       // structured event
       if (version && !acceptsVersion(version)) {
@@ -52,7 +53,7 @@ function use(fastify, opts, done) {
 }
 
 async function unmarshallEvent(request) {
-  const version = request.headers['ce-specversion'];
+  const version = request.headers[Spec.version];
   if (!version) {
     // it's a structured event and the version is in the body
     // currently only v1 structured events are supported

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 const framework = require('..');
 const test = require('tape');
 const request = require('supertest');
+const Spec = require('../lib/ce-constants.js').Spec;
 
 // paackage.json handling
 const { existsSync, readdirSync } = require('fs');
@@ -85,10 +86,10 @@ test('Responds to 0.2 binary cloud events', t => {
     request(server)
       .post('/')
       .send({ message: 'hello' })
-      .set('Ce-id', '1')
-      .set('Ce-source', 'integration-test')
-      .set('Ce-type', 'dev.knative.example')
-      .set('Ce-specversion', '0.2')
+      .set(Spec.id, '1')
+      .set(Spec.source, 'integration-test')
+      .set(Spec.type, 'dev.knative.example')
+      .set(Spec.version, '0.2')
       .expect(200)
       .expect('Content-Type', /json/)
       .end((err, res) => {
@@ -106,10 +107,10 @@ test('Responds to 0.3 binary cloud events', t => {
     request(server)
       .post('/')
       .send({ message: 'hello' })
-      .set('Ce-id', '1')
-      .set('Ce-source', 'integration-test')
-      .set('Ce-type', 'dev.knative.example')
-      .set('Ce-specversion', '0.3')
+      .set(Spec.id, '1')
+      .set(Spec.source, 'integration-test')
+      .set(Spec.type, 'dev.knative.example')
+      .set(Spec.version, '0.3')
       .expect(200)
       .expect('Content-Type', /json/)
       .end((err, res) => {
@@ -127,10 +128,10 @@ test('Responds to 1.0 binary cloud events', t => {
     request(server)
       .post('/')
       .send({ message: 'hello' })
-      .set('Ce-id', '1')
-      .set('Ce-source', 'integration-test')
-      .set('Ce-type', 'dev.knative.example')
-      .set('Ce-specversion', '1.0')
+      .set(Spec.id, '1')
+      .set(Spec.source, 'integration-test')
+      .set(Spec.type, 'dev.knative.example')
+      .set(Spec.version, '1.0')
       .expect(200)
       .expect('Content-Type', /json/)
       .end((err, res) => {
@@ -175,10 +176,10 @@ test('Responds with 406 Not Acceptable to unknown cloud event versions', t => {
     request(server)
       .post('/')
       .send({ message: 'hello' })
-      .set('Ce-id', '1')
-      .set('Ce-source', 'integration-test')
-      .set('Ce-type', 'dev.knative.example')
-      .set('Ce-specversion', '11.0')
+      .set(Spec.id, '1')
+      .set(Spec.source, 'integration-test')
+      .set(Spec.type, 'dev.knative.example')
+      .set(Spec.version, '11.0')
       .expect(406)
       .expect('Content-Type', /json/)
       .end((err, res) => {


### PR DESCRIPTION
This commit adds constants for the HTTP headers that are used for cloud
events.